### PR TITLE
Do not check if Tenancy is installed when running in console

### DIFF
--- a/src/Environment.php
+++ b/src/Environment.php
@@ -46,8 +46,8 @@ class Environment
 
         $this->defaults();
 
-        if ($this->installed() &&
-            (! $app->runningInConsole() || $app->runningUnitTests()) &&
+        if ((! $app->runningInConsole() || $app->runningUnitTests()) &&
+            $this->installed() &&
             config('tenancy.hostname.auto-identification')) {
             $this->identifyHostname();
             // Identifies the current hostname, sets the binding using the native resolving strategy.


### PR DESCRIPTION
Problem: the `if` first checked if the package is installed, and *then* if we are running in console. That means that the console tries to connect to the database, which may not be the case (e.g. when deploying an application or running in CI).

Solution: the `if` is now inverted and we first check if we are running in console (or tests) **before** checking if the package is installed.